### PR TITLE
Fix `Vec<Vec<u8>>` and `std::backtrace::Backtrace`

### DIFF
--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -235,7 +235,7 @@ macro_rules! dart_typed_data_type_trait_impl {
                     vec_to_dart_native_external_typed_data(self)
                 }
             }
-            
+
             impl IntoDartExceptPrimitive for Vec<$rust_type> {}
 
             impl IntoDart for HashSet<$rust_type> {

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -235,6 +235,8 @@ macro_rules! dart_typed_data_type_trait_impl {
                     vec_to_dart_native_external_typed_data(self)
                 }
             }
+            
+            impl IntoDartExceptPrimitive for Vec<$rust_type> {}
 
             impl IntoDart for HashSet<$rust_type> {
                 fn into_dart(self) -> DartCObject {

--- a/src/into_dart.rs
+++ b/src/into_dart.rs
@@ -53,6 +53,12 @@ impl IntoDart for anyhow::Error {
     }
 }
 
+impl IntoDart for std::backtrace::Backtrace {
+    fn into_dart(self) -> DartCObject {
+        format!("{:?}", self).into_dart()
+    }
+}
+
 #[cfg(feature = "backtrace")]
 impl IntoDart for backtrace::Backtrace {
     fn into_dart(self) -> DartCObject {

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -224,6 +224,8 @@ fn main() {
     assert!(isolate.post(HashSet::from([200])));
     assert!(isolate.post(HashSet::from([200u8])));
 
+    assert!(isolate.post(vec![vec![10u8]]));
+
     println!("all done!");
 }
 

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -193,6 +193,7 @@ fn main() {
 
     #[cfg(feature = "anyhow")]
     assert!(isolate.post(return_anyhow_error()));
+    assert!(isolate.post(std::backtrace::Backtrace::capture()));
     #[cfg(feature = "backtrace")]
     assert!(isolate.post(return_backtrace()));
     #[cfg(feature = "chrono")]


### PR DESCRIPTION
Without the fix, it errors like:

```
(base) ➜  allo-isolate git:(master) ✗ cargo test
warning: file `/Volumes/MyExternal/ExternalRefCode/allo-isolate/tests/containers.rs` found to be present in multiple build targets:
  * `example` target `containers`
  * `integration-test` target `containers`
   Compiling allo-isolate v0.1.23 (/Volumes/MyExternal/ExternalRefCode/allo-isolate)
error[E0277]: the trait bound `Vec<Vec<u8>>: IntoDart` is not satisfied
   --> tests/containers.rs:227:26
    |
227 |     assert!(isolate.post(vec![vec![10u8]]));
    |                     ---- ^^^^^^^^^^^^^^^^ the trait `IntoDart` is not implemented for `Vec<Vec<u8>>`
    |                     |
    |                     required by a bound introduced by this call
    |
    = help: the following other types implement trait `IntoDart`:
              Vec<i8>
              Vec<i16>
              Vec<i32>
              Vec<i64>
              Vec<u8>
              Vec<u16>
              Vec<u32>
              Vec<u64>
            and 3 others
note: required by a bound in `Isolate::post`
   --> /Volumes/MyExternal/ExternalRefCode/allo-isolate/src/lib.rs:133:34
    |
133 |     pub fn post(&self, msg: impl IntoDart) -> bool {
    |                                  ^^^^^^^^ required by this bound in `Isolate::post`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `allo-isolate` (test "containers") due to previous error
warning: build failed, waiting for other jobs to finish...
(base) ➜  allo-isolate git:(master) ✗ 