### PR TITLE
Fix panic when dropping vectors using ZeroCopyBuffer

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -182,6 +182,9 @@ impl Drop for DartCObject {
                 struct MyVisitor<'a>(&'a DartNativeTypedData);
                 impl DartTypedDataTypeVisitor for MyVisitor<'_> {
                     fn visit<T: DartTypedDataTypeTrait>(&self) {
+                        if self.0.values.is_null() {
+                            return;
+                        }
                         let _ = unsafe {
                             Vec::from_raw_parts(
                                 self.0.values as *mut T,

--- a/tests/containers.rs
+++ b/tests/containers.rs
@@ -245,6 +245,11 @@ fn main() {
 
     assert!(isolate.post(vec![vec![10u8]]));
 
+    // Test case to verify that dropping vectors using ZeroCopyBuffer no longer causes a panic
+    let a: ZeroCopyBuffer<Vec<u64>> = ZeroCopyBuffer(vec![]);
+    let b = a.into_dart();
+    drop(b);
+
     println!("all done!");
 }
 


### PR DESCRIPTION
Related to #59

Fix the panic issue when dropping vectors using `ZeroCopyBuffer`.

- **src/ffi.rs**: Add a check for a null pointer before deallocating memory in the `Drop` implementation of `DartCObject`.
- **tests/containers.rs**: Add a test case to verify that dropping vectors using `ZeroCopyBuffer` no longer causes a panic.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shekohex/allo-isolate/issues/59?shareId=af8684b4-bd08-4aca-be0c-22884e125c23).